### PR TITLE
Fix typeOf from old MooTools 1.2

### DIFF
--- a/Source/placeholder.js
+++ b/Source/placeholder.js
@@ -52,7 +52,7 @@ NS.Placeholder = new Class({
 
 		// Retrieving elements to check
 		var elements;
-		switch ($type(this.options.elements))
+		switch (typeOf(this.options.elements))
 		{
 			case 'string':
 				elements = $$(this.options.elements);


### PR DESCRIPTION
Mootools now uses typeOf instead of $type
